### PR TITLE
Add clang-format style and usage notes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+Language:        C
+BasedOnStyle:    GNU
+Standard:        C89
+UseTab:          Always
+IndentWidth:     8
+TabWidth:        8
+ColumnLimit:     80
+BreakBeforeBraces: Attach
+

--- a/v9/README
+++ b/v9/README
@@ -250,3 +250,14 @@ Some known bugs (I'm sure there are more):
 	RM 2B-424
 	600 Mountain Ave
 	Murray Hill, N.J.  07974
+
+FORMATTER USAGE
+---------------
+The repository includes a `.clang-format` file that defines the coding
+style. To format a file in place run:
+
+    clang-format -i path/to/file.c
+
+To see formatting changes without modifying the file use:
+
+    clang-format path/to/file.c | diff -u path/to/file.c -


### PR DESCRIPTION
## Summary
- add `.clang-format` with C89 configuration
- document how to run `clang-format` in `README`

## Testing
- `clang-format --version`