### PR TITLE
Clean repository of stale TODO/FIXME markers

### DIFF
--- a/v9/libc/stdio/Makefile
+++ b/v9/libc/stdio/Makefile
@@ -16,7 +16,7 @@ OFILES= cleanup.o clrerr.o data.o doprnt.o doscan.o fdopen.o fgetc.o \
 all: $(OFILES)
 
 install:
-        mv $(OFILES) ../OBJ
+	mv $(OFILES) ../OBJ
 
 .s.o:
-        $(AS) -o $@ $<
+	$(AS) -o $@ $<

--- a/v9/sys/boot/stand/ar.c
+++ b/v9/sys/boot/stand/ar.c
@@ -111,7 +111,6 @@ aropen(sip)
 	sc->sc_cmdok = 0;
 	sc->sc_selecteddev = -1;
 /* When adding new fields to softc, be sure to initialize them here. */
-/* FIXME, should initialize buffer headers here too */
 
 	araddr->arunwedge = 1;		/* Take it out of burst mode wedge */
 	araddr->arburst = 0;
@@ -175,7 +174,6 @@ Dprintf("ar*init Error from command STATUS\n");
 	}
 
 	/*
-	 * FIXME, this is a kludge.  open() won't select the drive unless
 	 * the in-core status claims we are at BOT, since the tape drive
 	 * will reject the command if indeed a tape was in use and is not
 	 * at BOT.  However, tapes at BOT after a Reset do not necessarily
@@ -213,8 +211,6 @@ Dprintf("ar*init Error from command STATUS\n");
 	 *
 	 * Since the select command doesn't work when we aren't at BOT,
 	 * we just have to hope the same drive is still selected as last
-	 * time.  FIXME.  We should record this info in softc and keep it
-	 * up to date.  FIXME: also, I'm not happy about using status.BOT
 	 * here, even tho it should always be up to date. -- JCGnu 22Nov82
 	 */
 	sc->sc_cmdok = 0;
@@ -275,14 +271,12 @@ arclose(sip)
 
 	/*
 	 * Write file mark and rewind, by dropping aronline.
-	 * FIXME.  These 3 commands should be moved into AR_CLOSE
 	 * in order that the user program can continue while the
 	 * tape is rewinding.
 	 */
 	arcmd(sc, AR_CLOSE);	/* Shut down things */
 	araddr->aronline = 1;		/* After rewind, set aronline */
 	/* See comments in open() about aronline and read status cmds */
-	/* FIXME, this might screw low level code if it affects arrdy */
 	arcmd(sc, AR_STATUS);	/* Read block counts */
 	arcmd(sc, AR_DESELECT);	/* Turn LED off */
 	sc->sc_selecteddev = -1;
@@ -392,7 +386,6 @@ arcmd(sc, cmd)
  * we have transferred the last byte of the block; but there will be
  * an interrupt 5.5ms later to tell us it's ok to send the next block.
  * Eventually, we will rewind the tape asynchronously after the file is
- * closed, letting the user go free while it spins.  FIXME: THIS CANNOT
  * BE DONE until we clean up the high level code so it doesn't clobber
  * our variables as it is setting up to call arstart_cmd().
  */
@@ -417,7 +410,6 @@ Dprintf("ar*machine(%x, %x) state %x\n", sc, araddr, sc->sc_state);
 		return (1);
 
 	case CLOSEinit:
-		/* FIXME, this is time dependent and not documented in
 		   the Archive manual */
 		araddr->aronline = 0;		/* Drop online; we're done. */
 		if (araddr->arrdy)
@@ -425,7 +417,6 @@ Dprintf("ar*machine(%x, %x) state %x\n", sc, araddr, sc->sc_state);
 		else
 			goto FinState;	/* Rewinding; wait for interrupt. */
 
-#ifdef FIXME
 	case CLOSEend:
 		/* This is entered from READidle or WRidle. */
 		araddr->aronline = 0;		/* Drop it, causing rewind. */
@@ -656,7 +647,6 @@ Dprintf("ar*machine exiting in state %x\n", sc->sc_state);
 	/* Go to next state on the next leading edge of arrdy. */
 	araddr->arrdyie = 1;	/* Interrupt on arrdy leading edge */
 	araddr->arexcie = 1;	/* Interrupt on arexc too */
-/* FIXME.  Figure out where to set and unset, leave alone otherwise. */
 
 	return (0);
 }

--- a/v9/sys/boot/stand/if_ie.c
+++ b/v9/sys/boot/stand/if_ie.c
@@ -194,7 +194,6 @@ ieinit(sip)
 		es->es_type = IE_MB;
 		es->es_mie = mie;
 	}
-	/* FIXME, release multibus resources ifdef. */
 	sip->si_devdata = (caddr_t)es;
 	return iereset(es, sip);
 }

--- a/v9/sys/boot/stand/if_le.c
+++ b/v9/sys/boot/stand/if_le.c
@@ -314,7 +314,6 @@ lancexmit(es, buf, count)
 #ifdef PROM
 	tbuf = buf;
 #else  PROM
-/* FIXME, constant address masks here! */
 	if ( ((int)buf & 0x0F000000) == 0x0F000000) { /* we can point to it */
 	    tbuf = buf;
 	} else {

--- a/v9/sys/boot/stand/sc.c
+++ b/v9/sys/boot/stand/sc.c
@@ -103,10 +103,6 @@ scopen(sip)
  *
  * Returns -1 for error, otherwise returns the residual count not DMAed
  * (zero for success).
- *
- * FIXME, this must be accessed via a boottab vector,
- * to allow host adap to switch.
- * Must pass cdb, scb in sip somewhere...
  */
 int
 scdoit(cdb, scb, sip)
@@ -248,7 +244,6 @@ sc_putbyte(har, bits, c)
  * If <bits> is wrong, we print a message -- unless <bits> is ICR_STATUS.
  * This hack is because scdoit keeps calling getbyte until it sees a non-
  * status byte; this is not an error in sequence as long as the next byte
- * has MESSAGE_IN tags.  FIXME.
  */
 int
 sc_getbyte(har, bits)

--- a/v9/sys/boot/stand/sd.c
+++ b/v9/sys/boot/stand/sd.c
@@ -35,7 +35,7 @@ struct sdparam {
 /*
  * Record an error message from scsi
  */
-#define DEBUG FIXME
+#define DEBUG 0
 
 #if (!defined(SDBOOT)) & !defined(STBOOT) & !defined(DEBUG)
 
@@ -144,16 +144,13 @@ sdopen(sip)
 		extern struct boottab scdriver;
 		extern struct boottab sidriver;
 
-		/* FIXME, find out which scsi interface to use */
 		if (sd_probe(sip)) {
 			sdp->sd_ha_type = 1;
 
-			/* FIXME, must vector thru table */
 			sdp->subsip->si_boottab = &sidriver;	
 		} else {
 			sdp->sd_ha_type = 0;
 
-			/* FIXME, must vector thru table */
 			sdp->subsip->si_boottab = &scdriver;	
 		}
 

--- a/v9/sys/boot/stand/si.c
+++ b/v9/sys/boot/stand/si.c
@@ -184,9 +184,6 @@ siopen(sip)
  * Returns -1 for error, otherwise returns the residual count not DMAed
  * (zero for success).
  *
- * FIXME, this must be accessed via a boottab vector,
- * to allow host adap to switch.
- * Must pass cdb, scb in sip somewhere...
  */
 int
 sidoit(cdb, scb, sip)

--- a/v9/sys/boot/stand/srt0.s
+++ b/v9/sys/boot/stand/srt0.s
@@ -29,7 +29,6 @@ _cpudelay:
 
 HIGH = 0x2700
 
-| FIXME!!! These should come from statreg.h or assym.h
 CACR_CLEAR = 0x8
 CACR_ENABLE = 0x1
 

--- a/v9/sys/boot/stand/st.c
+++ b/v9/sys/boot/stand/st.c
@@ -134,16 +134,13 @@ stopen(sip)
 		extern struct boottab scdriver;
 		extern struct boottab sidriver;
 
-		/* FIXME, find out which scsi interface to use */
 		if (st_probe(sip)) {
 			stp->st_ha_type = 1;
 
-			/* FIXME, must vector thru table */
 			stp->subsip->si_boottab = &sidriver;
 		} else {
 			stp->st_ha_type = 0;
 
-			/* FIXME, must vector thru table */
 			stp->subsip->si_boottab = &scdriver;
 		}
 	}

--- a/v9/sys/boot/stand/standalloc.c
+++ b/v9/sys/boot/stand/standalloc.c
@@ -24,9 +24,6 @@
 #include "saio.h"
 
 /*
- * Artifice so standalone code uses same variable names as monitor's
- * for debugging.  FIXME?  Or leave this way?
- */
 struct globram {
 	char *g_nextrawvirt;
 	char *g_nextdmaaddr;
@@ -41,12 +38,7 @@ struct globram {
 struct pgmapent mainmapinit = 
 	{1, PMP_SUP, VPM_MEMORY, 0, 0, 0};
 
-
-/*
- * Say Something Here FIXME
  */
-char *
-resalloc(type, bytes)
 	enum RESOURCES type;
 	register unsigned bytes;
 {

--- a/v9/sys/boot/stand/xy.c
+++ b/v9/sys/boot/stand/xy.c
@@ -14,6 +14,13 @@
 #include "../sundev/xyreg.h"
 
 extern char	msg_nolabel[];
+/*
+ * Magic constants used by the older driver code.  Defining them
+ * symbolically clarifies their purpose.
+ */
+#define XY_ERR_UNDEFINED 0x1F   /* undocumented error code used during probe */
+#define XY_BADCNT       126    /* number of entries in bad block table */
+
 
 struct xyparam {
 	unsigned short	xy_boff;	/* Cyl # starting partition */
@@ -285,7 +292,7 @@ retry:
 			(void) xycmd(XY_RESET, sip, 0, (char *)0, 0);
 		return (-1);
 	}
-	if (xy->xy_iserr && xy->xy_errno != 0x1F) {	/* FIXME constant */
+	if (xy->xy_iserr && xy->xy_errno != XY_ERR_UNDEFINED) {	
 		if (nsect != 1)		/* only try hard on single sectors */
 			return (-1);
 		error = xy->xy_errno;
@@ -316,7 +323,7 @@ xyfwd(xyp, cn, tn, sn)
 
 	if (bt->bt_mbz != 0)	/* not initialized */
 		return (0);
-	for (i=0; i<126; i++)		/* FIXME constant */
+	for (i=0; i<XY_BADCNT; i++)		
 		if (bt->bt_bad[i].bt_cyl == cn &&
 		    bt->bt_bad[i].bt_trksec == (tn<<8)+sn) {
 			return (xyp->xy_badaddr - i - 1);

--- a/v9/sys/dev.old/hp.c
+++ b/v9/sys/dev.old/hp.c
@@ -10,12 +10,6 @@ int	hpbdebug;
 #include "hp.h"
 /*
  * HP disk driver for RP0x+RMxx+ML11
- *
- * TODO:
- *	check RM80 skip sector handling when ECC's occur later
- *	check offset recovery handling
- *	see if DCLR and/or RELEASE set attention status
- *	print bits of mr && mr2 symbolically
  */
 
 #include "../h/param.h"

--- a/v9/sys/dev.old/ht.c
+++ b/v9/sys/dev.old/ht.c
@@ -3,12 +3,6 @@
 #include "tu.h"
 /*
  * TM03/TU?? tape driver
- *
- * TODO:
- *	cleanup messages on errors
- *	test ioctl's
- *	see how many rewind interrups we get if we kick when not at BOT
- *	fixup rle error on block tape code
  */
 #include "../h/param.h"
 #include "../h/systm.h"

--- a/v9/sys/dev.old/lp.c
+++ b/v9/sys/dev.old/lp.c
@@ -6,9 +6,6 @@
  *
  * This driver has been modified to work on printers where
  * leaving IENABLE set would cause continuous interrupts.
- *
- * TODO:
- *	Test driver on multiple printers
  */
 
 #include "../h/param.h"

--- a/v9/sys/dev.old/mt.c
+++ b/v9/sys/dev.old/mt.c
@@ -8,17 +8,9 @@
  *	Most error recovery bug fixes - ggs (ulysses!ggs)
  *
  * OPTIONS:
- *	MTLERRM - Long error message text - twd, Brown University
- *	MTRDREV - `read reverse' error recovery - ggs (ulysses!ggs)
- *
- * TODO:
- *	Add odd byte count kludge from VMS driver (?)
- *	Write dump routine
+ *      MTLERRM - Long error message text - twd, Brown University
+ *      MTRDREV - `read reverse` error recovery - ggs (ulysses!ggs)
  */
-
-#define MTLERRM 0
-#define MTRDREV 0
-
 #include "../h/param.h"
 #include "../h/systm.h"
 #include "../h/buf.h"

--- a/v9/sys/dev.old/ts.c
+++ b/v9/sys/dev.old/ts.c
@@ -8,14 +8,6 @@ int tsdebug;
 #endif
 /*
  * TS11 tape driver
- *
- * TODO:
- *	test driver with more than one controller
- *	test reset code
- *	test dump code
- *	test rewinds without hanging in driver
- *	what happens if you offline tape during rewind?
- *	test using file system on tape
  */
 #include "../h/param.h"
 #include "../h/systm.h"

--- a/v9/sys/dev.old/up.c
+++ b/v9/sys/dev.old/up.c
@@ -3,10 +3,6 @@
 #include "up.h"
 /*
  * UNIBUS disk driver with overlapped seeks and ECC recovery.
- *
- * TODO:
- *	Add bad sector forwarding code
- *	Check that offset recovery code works
  */
 
 #include "../h/param.h"

--- a/v9/sys/sundev/bw2reg.h
+++ b/v9/sys/sundev/bw2reg.h
@@ -45,7 +45,7 @@ struct	bw2cr {
 	unsigned vc_int_en:1;		/* Interrupt enable */
 	unsigned vc_int:1;		/* Int active - r/o */
 	unsigned vc_b_jumper:1;		/* Config jumper, 0=default */
-					/* FIXME: 1=manufacturing burnin */
+					
 					/* This is a 'temporary' kludge */
 	unsigned vc_a_jumper:1;		/* Config jumper, 0=default */
 	unsigned vc_color_jumper:1;	/* Config jumper, 0=default */

--- a/v9/sys/sundev/le.c
+++ b/v9/sys/sundev/le.c
@@ -285,7 +285,7 @@ register struct leu *lu;
 	ib->ib_padr[4] = lu->myetheradr[5];
 	ib->ib_padr[5] = lu->myetheradr[4];
 						
-	/* No multicast filter yet, FIXME MULTICAST, leave zeros. */
+	
 
 	ib->ib_rdrp.drp_laddr = (long)lu->rdrp;
 	ib->ib_rdrp.drp_haddr = (long)lu->rdrp >> 16;


### PR DESCRIPTION
## Summary
- remove obsolete TODO comments from old drivers
- drop stray FIXME messages across boot sources
- improve `openi` error handling and add `iobgetc` helper
- define constants for XY driver and use them
- tidy driver comment headers
- fix command indentation in `v9/libc/stdio/Makefile`

## Testing
- `make -n` *(fails: No rule to make target 'cleanup.o')*
