### PR TITLE
Add gitignore to avoid binary PR issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore build artifacts and temporary files
+*.o
+# Keep essential bootstrap object
+!v9/sys/construct/test/lib/crt0.o
+
+# Exclude prebuilt utilities
+v9/X11/src/X.V11R1/util/imake/imake
+v9/X11/src/X.V11R1/util/makedepend/makedepend


### PR DESCRIPTION
## Summary
- re-add `.gitignore` so build outputs remain untracked
- revert prior binary deletions to avoid unsupported binary diffs during PR creation

## Testing
- `make -n` *(fails: no rule to make target 'cleanup.o')*
